### PR TITLE
Reduces image size 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM httpd:2.4.46-alpine
 
-
 COPY ./mr_project /var/www/html/mr_project
 ADD ./docker/httpd.conf /usr/local/apache2/conf/httpd.conf
 ADD ./docker/entrypoint.sh /entrypoint.sh
 ADD ./requirements.txt /tmp/requirements.txt
 RUN chmod +x /entrypoint.sh
 
-RUN apk update && apk add python3-dev==3.8.5-r0 py3-pip==20.1.1-r0 postgresql-dev==12.3-r2 \
-    gcc==9.3.0-r2 musl-dev==1.1.24-r9 make==4.3-r0 expat-dev==2.2.9-r1 apache2-mod-wsgi==4.7.1-r0 \
-    apr-dev==1.7.0-r0 apr-util-dev==1.6.1-r6 apache2-mod-wsgi==4.7.1-r0
-RUN pip3 install -r /tmp/requirements.txt
-RUN cp /usr/lib/apache2/mod_wsgi.so /usr/local/apache2/modules/
+RUN apk update \
+    && apk add --no-cache python3-dev==3.8.5-r0 py3-pip==20.1.1-r0 postgresql-dev==12.3-r2 \
+    && apk add --no-cache --virtual build-deps gcc==9.3.0-r2 musl-dev==1.1.24-r9 apache2-mod-wsgi==4.7.1-r0 \
+    && pip3 install --no-cache-dir -r /tmp/requirements.txt \
+    && cp /usr/lib/apache2/mod_wsgi.so /usr/local/apache2/modules/ \
+    && apk del --purge build-deps
 
 EXPOSE 80
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -x
 MR_PATH="/var/www/html/mr_project"


### PR DESCRIPTION
Docker image size reduced from 593 MB to 400 MB by removing unneeded packages and reducing image layers. 400 MB is still pretty large, however, further reducing the image size will be difficult as the current design requires the project dependencies (`requirements.txt`), `postgresql-dev`, and apache at runtime. 